### PR TITLE
Fix extraction of map elements from the trace context

### DIFF
--- a/src/main/java/io/opentracing/thrift/ServerProtocolDecorator.java
+++ b/src/main/java/io/opentracing/thrift/ServerProtocolDecorator.java
@@ -46,7 +46,9 @@ class ServerProtocolDecorator extends TProtocolDecorator {
   public ByteBuffer readBinary() throws TException {
     ByteBuffer byteBuffer = super.readBinary();
     if (nextSpan) {
-      mapElements.add(new String(byteBuffer.array()));
+      byte[] bytes = new byte[byteBuffer.remaining()];
+      byteBuffer.get(bytes, 0, bytes.length);
+      mapElements.add(new String(bytes));
     }
 
     return byteBuffer;


### PR DESCRIPTION
When extracting the fields of the trace context from the Thrift magic
field, the code was not correctly building the String object for each
map element by not taking into account the position and limit of the
byte buffer.

Signed-off-by: Maxime Petazzoni <maxime.petazzoni@bulix.org>