### PR TITLE
Server span should be a child of the client span

### DIFF
--- a/src/main/java/io/opentracing/thrift/ServerProtocolDecorator.java
+++ b/src/main/java/io/opentracing/thrift/ServerProtocolDecorator.java
@@ -13,7 +13,6 @@
  */
 package io.opentracing.thrift;
 
-import io.opentracing.References;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -109,7 +108,7 @@ class ServerProtocolDecorator extends TProtocolDecorator {
         .extract(Builtin.TEXT_MAP, new TextMapExtractAdapter(mapSpanContext));
 
     if (parent != null) {
-      spanBuilder.addReference(References.FOLLOWS_FROM, parent);
+      spanBuilder.asChildOf(parent);
     }
     Span span = spanBuilder.startActive(true).span();
     SpanDecorator.decorate(span, message);


### PR DESCRIPTION
RPC client/server exchange are the canonical example given in the
OpenTracing specification for using a "ChildOf" relationship between the
server-side span that handles the request and the client-side span that
triggered it.

See https://github.com/opentracing/specification/blob/master/specification.md#references-between-spans