### PR TITLE
Make client-side span tagging customisable

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ TProtocol spanProtocol = new SpanProtocol(protocol, tracer, new MyClientSpanDeco
 
 If no custom ClientSpanDecorator is provided, the DefaultClientSpanDecorator is used.
 This delegates its methods to the static methods in the SpanDecorator class.
-TThe DefaultClientSpanDecorator can be extended if you want to add to the default behaviour.
+The DefaultClientSpanDecorator can be extended if you want to add to the default behaviour.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,38 @@ asyncClient.callMethod(..., tracingCallback);
 
 ```
 
+### Custom Client Span Tags
+To customise the tags added to spans on the client side, create a custom implementation of ClientSpanDecorator.
+
+```java
+
+class MyClientSpanDecorator implements ClientSpanDecorator {
+    
+    @Override
+    public void decorate(Span span, TMessage message) {
+        // Add custom tags to the span.
+    }
+    
+    @Override
+    public void onError(Throwable throwable, Span span) {
+        // Add custom tags for when an error is thrown by the thrift call.
+    }
+}
+
+```
+
+Then pass this into your SpanProtocol.
+
+```java
+
+TProtocol spanProtocol = new SpanProtocol(protocol, tracer, new MyClientSpanDecorator() );
+
+```
+
+If no custom ClientSpanDecorator is provided, the DefaultClientSpanDecorator is used.
+This delegates its methods to the static methods in the SpanDecorator class.
+TThe DefaultClientSpanDecorator can be extended if you want to add to the default behaviour.
+
 ## License
 
 [Apache 2.0 License](./LICENSE).

--- a/src/main/java/io/opentracing/thrift/ClientSpanDecorator.java
+++ b/src/main/java/io/opentracing/thrift/ClientSpanDecorator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.thrift;
+
+import io.opentracing.Span;
+import org.apache.thrift.protocol.TMessage;
+
+/**
+ * Decorator for Spans generated on the client side.
+ */
+class ClientSpanDecorator {
+
+  /**
+   * Decorate a span with information from a TMessage.
+   *
+   * @param span Span.
+   * @param message TMessage.
+   */
+  public void decorate(Span span, TMessage message) {
+    SpanDecorator.decorate(span, message);
+  }
+
+  /**
+   * Decorate a span with information from a caught throwable.
+   *
+   * @param span Span.
+   * @param throwable Throwable.
+   */
+  public void onError(Throwable throwable, Span span) {
+    SpanDecorator.onError(throwable, span);
+  }
+}

--- a/src/main/java/io/opentracing/thrift/DefaultClientSpanDecorator.java
+++ b/src/main/java/io/opentracing/thrift/DefaultClientSpanDecorator.java
@@ -17,22 +17,17 @@ import io.opentracing.Span;
 import org.apache.thrift.protocol.TMessage;
 
 /**
- * Interface for decorating Spans generated on the client side of a Thrift call.
+ * Default decorator for spans generated on the client side.
  */
-public interface ClientSpanDecorator {
-    /**
-     * Decorate a span with information from a TMessage.
-     *
-     * @param span    Span.
-     * @param message TMessage.
-     */
-    void decorate(Span span, TMessage message);
+public class DefaultClientSpanDecorator implements ClientSpanDecorator {
 
-    /**
-     * Decorate a span with information from a caught throwable.
-     *
-     * @param span      Span.
-     * @param throwable Throwable.
-     */
-    void onError(Throwable throwable, Span span);
+  @Override
+  public void decorate(Span span, TMessage message) {
+    SpanDecorator.decorate(span, message);
+  }
+
+  @Override
+  public void onError(Throwable throwable, Span span) {
+    SpanDecorator.onError(throwable, span);
+  }
 }

--- a/src/main/java/io/opentracing/thrift/SpanProtocol.java
+++ b/src/main/java/io/opentracing/thrift/SpanProtocol.java
@@ -70,7 +70,7 @@ public class SpanProtocol extends TProtocolDecorator {
    * @param tracer Tracer.
    */
   public SpanProtocol(TProtocol protocol, Tracer tracer) {
-    this(protocol, tracer, new ClientSpanDecorator());
+    this(protocol, tracer, new DefaultClientSpanDecorator());
   }
 
   /**
@@ -94,7 +94,7 @@ public class SpanProtocol extends TProtocolDecorator {
     this.tracer = tracer;
     this.spanHolder = spanHolder;
     this.finishSpan = finishSpan;
-    this.spanDecorator = new ClientSpanDecorator();
+    this.spanDecorator = new DefaultClientSpanDecorator();
   }
 
   @Override

--- a/src/main/java/io/opentracing/thrift/SpanProtocol.java
+++ b/src/main/java/io/opentracing/thrift/SpanProtocol.java
@@ -48,6 +48,7 @@ public class SpanProtocol extends TProtocolDecorator {
   private final Tracer tracer;
   private final SpanHolder spanHolder;
   private final boolean finishSpan;
+  private final ClientSpanDecorator spanDecorator;
   static final short SPAN_FIELD_ID = 3333; // Magic number
   private boolean oneWay;
   private boolean injected;
@@ -69,10 +70,23 @@ public class SpanProtocol extends TProtocolDecorator {
    * @param tracer Tracer.
    */
   public SpanProtocol(TProtocol protocol, Tracer tracer) {
+    this(protocol, tracer, new ClientSpanDecorator());
+  }
+
+  /**
+   * Encloses the specified protocol.
+   * Adds a custom ProtocolSpanDecorator to add tags to spans.
+   *
+   * @param protocol All operations will be forward to this protocol.
+   * @param tracer Tracer.
+   * @param spanDecorator The ProtocolSpanDecorator to use to add tags to spans.
+   */
+  public SpanProtocol(TProtocol protocol, Tracer tracer, ClientSpanDecorator spanDecorator) {
     super(protocol);
     this.tracer = tracer;
     this.spanHolder = new SpanHolder();
     this.finishSpan = true;
+    this.spanDecorator = spanDecorator;
   }
 
   SpanProtocol(TProtocol protocol, Tracer tracer, SpanHolder spanHolder, boolean finishSpan) {
@@ -80,6 +94,7 @@ public class SpanProtocol extends TProtocolDecorator {
     this.tracer = tracer;
     this.spanHolder = spanHolder;
     this.finishSpan = finishSpan;
+    this.spanDecorator = new ClientSpanDecorator();
   }
 
   @Override
@@ -92,7 +107,7 @@ public class SpanProtocol extends TProtocolDecorator {
     oneWay = tMessage.type == TMessageType.ONEWAY;
     injected = false;
 
-    SpanDecorator.decorate(span, tMessage);
+    spanDecorator.decorate(span, tMessage);
     super.writeMessageBegin(tMessage);
   }
 
@@ -140,7 +155,7 @@ public class SpanProtocol extends TProtocolDecorator {
     } catch (TTransportException tte) {
       Span span = spanHolder.getSpan();
       if (span != null) {
-        SpanDecorator.onError(tte, span);
+        spanDecorator.onError(tte, span);
         if (finishSpan) {
           span.finish();
           spanHolder.setSpan(null);


### PR DESCRIPTION
I need to be able to add custom tags to the spans created on the client
side of my thrift calls. Currently this is not possible since the tags
are added in a static method that cannot be extended. Add an extensible
class, ClientSpanDecorator, which can be set on a SpanProtocol which is
used to decorate the spans. The default implementation of
ClientSpanDecorator delegates to the static methods of SpanDecorator to
ensure backwards compatibility. The ClientSpanDecorator can be extended
by consumers of the library when creating SpanProtocols to customise how
the spans are tagged.