### PR TITLE
Change span names to match Spond's span naming conventions

### DIFF
--- a/.settings.xml
+++ b/.settings.xml
@@ -39,5 +39,10 @@
       <username>${env.GH_USER}</username>
       <password>${env.GH_TOKEN}</password>
     </server>
+    <server>
+      <id>codeartifact</id>
+      <username>aws</username>
+      <password>${env.CODEARTIFACT_AUTH_TOKEN}</password>
+    </server>
   </servers>
 </settings>

--- a/README.md
+++ b/README.md
@@ -1,16 +1,35 @@
-[![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Released Version][maven-img]][maven] [![Apache-2.0 license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Apache-2.0 license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # OpenTracing Apache Thrift Instrumentation
-OpenTracing instrumentation for Apache Thrift
+OpenTracing instrumentation for Apache Thrift. 
+
+Forked and modified by [Spond](https://spond.com).
 
 pom.xml
 ```xml
 <dependency>
-    <groupId>io.opentracing.contrib</groupId>
+    <groupId>com.spond</groupId>
     <artifactId>opentracing-thrift</artifactId>
     <version>VERSION</version>
 </dependency>
 ```
+
+build.gradle
+```
+api 'com.spond:opentracing-thrift:{VERSION}'
+```
+
+## Publishing changes
+
+This fork has been modified with the ability to publish new versions to a [Code Artifact](https://aws.amazon.com/codeartifact/) Maven repository.
+
+Publishing a new version to code artifact can be done manually with the Maven command:
+```
+./mvnw deploy
+```
+This command requires the environment variables `CODEARTIFACT_REPO` and `CODEARTIFACT_AUTH_TOKEN` to be set.
+- `CODEARTIFACT_REPO`: The address of the code artifact repository to publish to
+- `CODEARTIFACT_AUTH_TOKEN`: A valid code artifact auth token with permissions to publish to the provideded repository.
 
 ## Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>com.spond</groupId>
   <artifactId>opentracing-thrift</artifactId>
-  <version>0.1.6-SNAPSHOT</version>
+  <version>0.1.7</version>
 
   <name>OpenTracing Instrumentation for Apache Thrift</name>
   <description>OpenTracing Instrumentation for Apache Thrift</description>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
     <opentracing.version>0.33.0</opentracing.version>
-    <thrift.version>0.14.0</thrift.version>
+    <thrift.version>0.14.2</thrift.version>
     <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.opentracing.contrib</groupId>
+  <groupId>com.spond</groupId>
   <artifactId>opentracing-thrift</artifactId>
-  <version>0.1.5-SNAPSHOT</version>
+  <version>0.1.6-SNAPSHOT</version>
 
   <name>OpenTracing Instrumentation for Apache Thrift</name>
   <description>OpenTracing Instrumentation for Apache Thrift</description>
@@ -155,55 +155,6 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
-        <configuration>
-          <useReleaseProfile>false</useReleaseProfile>
-          <releaseProfiles>release</releaseProfiles>
-          <autoVersionSubmodules>true</autoVersionSubmodules>
-          <tagNameFormat>@{project.version}</tagNameFormat>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>io.zipkin.centralsync-maven-plugin</groupId>
-        <artifactId>centralsync-maven-plugin</artifactId>
-        <version>0.1.1</version>
-        <configuration>
-          <subject>opentracing</subject>
-          <repo>maven</repo>
-          <packageName>opentracing-thrift</packageName>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.mycila</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <mapping>
-            <java>SLASHSTAR_STYLE</java>
-          </mapping>
-          <header>header.txt</header>
-          <strictCheck>true</strictCheck>
-          <excludes>
-            <exclude>LICENSE</exclude>
-            <exclude>mvnw</exclude>
-            <exclude>mvnw.cmd</exclude>
-            <exclude>.mvn/wrapper/maven-wrapper.properties</exclude>
-            <exclude>thrift-0.13.0/**</exclude>
-            <exclude>.coveralls.yml</exclude>
-            <exclude>src/test/thrift/custom.thrift</exclude>
-          </excludes>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>compile</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>${coveralls-maven-plugin.version}</version>
@@ -226,13 +177,10 @@
 
   <distributionManagement>
     <repository>
-      <id>bintray</id>
-      <url>https://api.bintray.com/maven/opentracing/maven/opentracing-thrift/;publish=1</url>
+      <id>codeartifact</id>
+      <name>codeartifact</name>
+      <url>${env.CODEARTIFACT_REPO}</url>
     </repository>
-    <snapshotRepository>
-      <id>jfrog-snapshots</id>
-      <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
-    </snapshotRepository>
   </distributionManagement>
 
   <profiles>

--- a/src/main/java/io/opentracing/thrift/ServerInProtocolDecorator.java
+++ b/src/main/java/io/opentracing/thrift/ServerInProtocolDecorator.java
@@ -48,7 +48,8 @@ class ServerInProtocolDecorator extends TProtocolDecorator {
     this.tracer = tracer;
     this.message = message;
 
-    spanBuilder = tracer.buildSpan(message.name)
+    spanBuilder = tracer.buildSpan("thrift.operation")
+        .withTag("resource_name", message.name)
         .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
   }
 

--- a/src/main/java/io/opentracing/thrift/SpanProtocol.java
+++ b/src/main/java/io/opentracing/thrift/SpanProtocol.java
@@ -105,7 +105,8 @@ public class SpanProtocol extends TProtocolDecorator {
     // Always reset the level at message begin.  The last field stop will insert the span at this level.
     level = 0;
 
-    Span span = tracer.buildSpan(tMessage.name)
+    Span span = tracer.buildSpan("thrift.call")
+        .withTag("resource_name", tMessage.name)
         .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
         .start();
     spanHolder.setSpan(span);


### PR DESCRIPTION
The main reason for this fork is to allow us to change the span names generated by this library, to use a naming convention which is more consistent with our other spans and tooling.

This changes the generated spans from using the Thrift message name as the span name, to using a fixed span name with the message name set at the "resource_name" tag. The new spans use `thrift.call` on the client side, and `thift.operation` on the server side.

This PR also incorporates the fix implemented here: https://github.com/jspofford/java-thrift/commit/e3b54db4d8fc9b4ceb3b1b734b27933706a5152c, as discussed in this issue: https://github.com/opentracing-contrib/java-thrift/issues/19. 
